### PR TITLE
Phase 3 — Baseline probability engine

### DIFF
--- a/.github/workflows/phase3-model-tests.yml
+++ b/.github/workflows/phase3-model-tests.yml
@@ -1,0 +1,36 @@
+name: Phase 3 Model Engine Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, phase3-probability-engine]
+  pull_request:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PYTHONPATH: ${{ github.workspace }}
+
+jobs:
+  validate-phase3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Static Phase 2 validation
+        run: |
+          python scripts/validate_phase2.py
+      - name: Static Phase 3 validation
+        run: |
+          python scripts/validate_phase3.py
+      - name: Run test suite
+        run: |
+          python -m pytest -vv

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Football Edge Agent — Phase 2 Backend Foundation — 08:33, 27.04.2026 Europe/Oslo
+# Football Edge Agent — Phase 3 Baseline Model and Probability Engine — 20:16, 27.04.2026 Europe/Oslo
 
-This repository contains the Phase 2 backend/data foundation for the Football Edge Intelligence Agent.
+This repository contains the Football Edge Intelligence Agent backend through Phase 3.
 
 ## Governance posture
 
@@ -8,6 +8,7 @@ This repository contains the Phase 2 backend/data foundation for the Football Ed
 - Default recommendation posture: **NO BET**.
 - No guaranteed picks, loss chasing, reckless staking, unsupported markets, or unsupported competitions.
 - Auto-betting is represented only as an inactive, hard-locked architecture placeholder.
+- Historical odds and xG are mandatory.
 - Eliteserien is the only approved Norwegian elite-league name.
 
 ## MVP competitions
@@ -24,21 +25,21 @@ This repository contains the Phase 2 backend/data foundation for the Football Ed
 ## MVP markets
 
 - 1X2
-- Over/Under 2.5 Goals
-- Both Teams To Score
+- Over/Under 2.5 Goals (`OVER_UNDER_2_5`)
+- Both Teams To Score (`BTTS`)
 
-## Mandatory data domains
+## Phase 3 model-engine features
 
-- Fixtures and results
-- Current odds
-- Historical odds
-- xG
-- Lineups
-- Injuries/suspensions
-- Provider timestamps
-- Provider audit trail
-- Data-quality scoring
-- Audit logging
+- Market-implied probability conversion from decimal odds.
+- No-vig probability and bookmaker margin calculation.
+- Elo foundation and Glicko scaffold.
+- xG rolling-strength inputs and Poisson expected-goals modelling.
+- Poisson market probability derivation for 1X2, O/U 2.5, and BTTS.
+- Ensemble blending of Poisson/xG, no-vig market baseline, and Elo signals.
+- Brier score, log loss, and calibration summary helpers.
+- Expected value, fair odds, edge, and minimum acceptable odds.
+- Recommendation logic restricted to `BET`, `WATCHLIST`, or `NO BET`.
+- Model probability vs bookmaker probability comparison chart output.
 
 ## Local startup
 
@@ -69,14 +70,26 @@ GET  /data-quality/{fixture_id}
 GET  /audit/fixture/{fixture_id}
 GET  /auto-betting/status
 POST /auto-betting/execute
+
+GET  /model/status
+POST /probabilities/calculate
+POST /recommendations/fixture/direct
+POST /backtests/summary
+```
+
+## Validation
+
+```bash
+python scripts/validate_phase2.py
+python scripts/validate_phase3.py
+python -m pytest -vv
 ```
 
 ## Documentation
 
-- `docs/implementation_instructions.md`
-- `docs/domain_and_hosting_domeneshop.md`
+- `docs/phase2_status_report.md`
+- `docs/phase3_model_probability_engine.md`
 - `docs/provider_setup.md`
 - `docs/api_contract.md`
 - `docs/database_schema.md`
 - `docs/validation_checklist.md`
-- `docs/phase2_completion_report_template.md`

--- a/backend/app/api/phase3.py
+++ b/backend/app/api/phase3.py
@@ -1,0 +1,106 @@
+"""Phase 3 API routes for the baseline probability engine."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from backend.app.models.phase3_probability_engine import (
+    ALLOWED_RECOMMENDATIONS,
+    MODEL_NAME,
+    MODEL_VERSION,
+    SUPPORTED_MARKETS,
+    build_recommendation_payload,
+    calibration_summary,
+    generate_market_probabilities,
+    glicko_placeholder_rating,
+)
+
+router = APIRouter(tags=["Phase 3 Model Engine"])
+
+
+class ProbabilityRequest(BaseModel):
+    market: str = Field(..., examples=["1X2", "OVER_UNDER_2_5", "BTTS"])
+    odds_by_selection: dict[str, float]
+    home_expected_goals: float = Field(..., ge=0)
+    away_expected_goals: float = Field(..., ge=0)
+    home_elo_rating: float = 1500.0
+    away_elo_rating: float = 1500.0
+    xg_available: bool = True
+    historical_odds_available: bool = True
+
+
+class RecommendationRequest(BaseModel):
+    fixture_id: int = Field(..., ge=1)
+    market: str
+    selection: str
+    decimal_odds: float = Field(..., gt=1.0)
+    model_probability: float = Field(..., ge=0, le=1)
+    bookie_probability: float = Field(..., ge=0, le=1)
+    data_quality_score: int = Field(..., ge=0, le=100)
+    xg_available: bool = True
+    historical_odds_available: bool = True
+    odds_fresh: bool = True
+    auto_betting_enabled: bool = False
+
+
+class CalibrationRow(BaseModel):
+    predicted_probability: float = Field(..., ge=0, le=1)
+    actual_outcome: int = Field(..., ge=0, le=1)
+
+
+class BacktestSummaryRequest(BaseModel):
+    rows: list[CalibrationRow]
+
+
+@router.get("/model/status")
+def model_status() -> dict[str, Any]:
+    return {
+        "status": "success",
+        "data": {
+            "model_name": MODEL_NAME,
+            "model_version": MODEL_VERSION,
+            "phase": 3,
+            "supported_markets": list(SUPPORTED_MARKETS.keys()),
+            "supported_recommendations": sorted(ALLOWED_RECOMMENDATIONS),
+            "mandatory_inputs": [
+                "current_odds",
+                "historical_odds",
+                "xG",
+                "fixtures",
+                "results",
+                "timestamps",
+                "provider_audit_trail",
+            ],
+            "glicko_scaffold": glicko_placeholder_rating(),
+            "default_recommendation": "NO BET",
+            "auto_betting_enabled": False,
+            "auto_betting_hard_locked": True,
+            "real_money_status": "not_approved",
+        },
+    }
+
+
+@router.post("/probabilities/calculate")
+def calculate_probabilities(request: ProbabilityRequest) -> dict[str, Any]:
+    try:
+        outputs = generate_market_probabilities(**request.model_dump())
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"status": "success", "data": outputs}
+
+
+@router.post("/recommendations/fixture/direct")
+def create_direct_recommendation(request: RecommendationRequest) -> dict[str, Any]:
+    try:
+        payload = build_recommendation_payload(**request.model_dump())
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"status": "success", "data": payload}
+
+
+@router.post("/backtests/summary")
+def summarize_backtest(request: BacktestSummaryRequest) -> dict[str, Any]:
+    rows = [row.model_dump() for row in request.rows]
+    return {"status": "success", "data": calibration_summary(rows)}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 
+from backend.app.api.phase3 import router as phase3_router
 from backend.app.config import get_settings
 from backend.app.providers.clients import get_provider_clients
 from backend.app.services.auto_betting_service import AutoBettingInactiveError, assert_auto_betting_allowed, get_auto_betting_status
@@ -104,3 +105,6 @@ async def execute_auto_bet():
     except AutoBettingInactiveError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
     return {"status": "blocked", "data": {"message": "Auto-betting execution is not implemented in Phase 2."}}
+
+
+router.include_router(phase3_router)

--- a/backend/app/db/migrations/003_model_probability_engine.sql
+++ b/backend/app/db/migrations/003_model_probability_engine.sql
@@ -1,0 +1,119 @@
+-- Football Edge Agent — Phase 3 Baseline Model and Probability Engine
+-- Migration: 003_model_probability_engine.sql
+-- Purpose: Persist model versions, model inputs, probability outputs,
+-- recommendation outputs, calibration runs, and backtest runs.
+
+CREATE TABLE IF NOT EXISTS model_versions (
+    id BIGSERIAL PRIMARY KEY,
+    model_name TEXT NOT NULL,
+    model_version TEXT NOT NULL UNIQUE,
+    phase INTEGER NOT NULL DEFAULT 3,
+    methodology TEXT NOT NULL,
+    supported_markets TEXT[] NOT NULL,
+    supported_recommendations TEXT[] NOT NULL DEFAULT ARRAY['BET','WATCHLIST','NO BET'],
+    auto_betting_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    auto_betting_hard_locked BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS model_inputs (
+    id BIGSERIAL PRIMARY KEY,
+    fixture_id BIGINT NOT NULL,
+    model_version TEXT NOT NULL REFERENCES model_versions(model_version),
+    market TEXT NOT NULL,
+    odds_by_selection JSONB NOT NULL,
+    home_expected_goals NUMERIC(10,6) NOT NULL,
+    away_expected_goals NUMERIC(10,6) NOT NULL,
+    home_elo_rating NUMERIC(10,3),
+    away_elo_rating NUMERIC(10,3),
+    xg_available BOOLEAN NOT NULL,
+    historical_odds_available BOOLEAN NOT NULL,
+    provider_audit_trail JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS probability_outputs (
+    id BIGSERIAL PRIMARY KEY,
+    model_input_id BIGINT REFERENCES model_inputs(id) ON DELETE CASCADE,
+    fixture_id BIGINT NOT NULL,
+    model_version TEXT NOT NULL REFERENCES model_versions(model_version),
+    market TEXT NOT NULL,
+    selection TEXT NOT NULL,
+    decimal_odds NUMERIC(10,4) NOT NULL,
+    model_probability NUMERIC(12,9) NOT NULL CHECK (model_probability >= 0 AND model_probability <= 1),
+    bookie_probability NUMERIC(12,9) NOT NULL CHECK (bookie_probability >= 0 AND bookie_probability <= 1),
+    market_probability_raw NUMERIC(12,9) NOT NULL,
+    market_probability_no_vig NUMERIC(12,9) NOT NULL,
+    bookmaker_margin NUMERIC(12,9) NOT NULL,
+    edge NUMERIC(12,9) NOT NULL,
+    expected_value NUMERIC(12,9) NOT NULL,
+    fair_odds NUMERIC(10,4),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS recommendation_outputs (
+    id BIGSERIAL PRIMARY KEY,
+    probability_output_id BIGINT REFERENCES probability_outputs(id) ON DELETE SET NULL,
+    fixture_id BIGINT NOT NULL,
+    model_version TEXT NOT NULL REFERENCES model_versions(model_version),
+    market TEXT NOT NULL,
+    selection TEXT NOT NULL,
+    recommendation TEXT NOT NULL CHECK (recommendation IN ('BET','WATCHLIST','NO BET')),
+    confidence TEXT NOT NULL CHECK (confidence IN ('LOW','MEDIUM','HIGH')),
+    risk TEXT NOT NULL CHECK (risk IN ('LOW','MEDIUM','HIGH')),
+    edge NUMERIC(12,9) NOT NULL,
+    expected_value NUMERIC(12,9) NOT NULL,
+    model_probability NUMERIC(12,9) NOT NULL,
+    bookie_probability NUMERIC(12,9) NOT NULL,
+    comparison_chart JSONB NOT NULL,
+    audit_trail JSONB NOT NULL,
+    hard_fail_reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS calibration_runs (
+    id BIGSERIAL PRIMARY KEY,
+    model_version TEXT NOT NULL REFERENCES model_versions(model_version),
+    market TEXT,
+    sample_size INTEGER NOT NULL DEFAULT 0,
+    brier_score NUMERIC(12,9),
+    log_loss NUMERIC(12,9),
+    calibration_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS backtest_runs (
+    id BIGSERIAL PRIMARY KEY,
+    model_version TEXT NOT NULL REFERENCES model_versions(model_version),
+    date_from DATE,
+    date_to DATE,
+    sample_size INTEGER NOT NULL DEFAULT 0,
+    roi NUMERIC(12,9),
+    yield_value NUMERIC(12,9),
+    maximum_drawdown NUMERIC(12,9),
+    no_bet_rate NUMERIC(12,9),
+    brier_score NUMERIC(12,9),
+    log_loss NUMERIC(12,9),
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO model_versions (
+    model_name,
+    model_version,
+    methodology,
+    supported_markets,
+    supported_recommendations,
+    auto_betting_enabled,
+    auto_betting_hard_locked
+)
+VALUES (
+    'football_edge_baseline_probability_engine',
+    '0.3.0-phase3',
+    'Market-implied probabilities, no-vig normalization, Elo/Glicko scaffold, Poisson goal model, xG inputs, ensemble blending, calibration metrics, and strict NO BET governance.',
+    ARRAY['1X2','OVER_UNDER_2_5','BTTS'],
+    ARRAY['BET','WATCHLIST','NO BET'],
+    FALSE,
+    TRUE
+)
+ON CONFLICT (model_version) DO NOTHING;

--- a/backend/app/models/phase3_probability_engine.py
+++ b/backend/app/models/phase3_probability_engine.py
@@ -1,0 +1,404 @@
+"""Phase 3 baseline probability engine.
+
+This module is intentionally deterministic and provider-agnostic. It implements
+the model scaffold required before live provider ingestion is enabled. All
+incomplete mandatory-data cases must resolve to NO BET.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import exp, factorial, log
+from typing import Iterable, Mapping
+
+MODEL_NAME = "football_edge_baseline_probability_engine"
+MODEL_VERSION = "0.3.0-phase3"
+
+SUPPORTED_MARKETS: dict[str, tuple[str, ...]] = {
+    "1X2": ("home", "draw", "away"),
+    "OVER_UNDER_2_5": ("over_2_5", "under_2_5"),
+    "BTTS": ("yes", "no"),
+}
+ALLOWED_RECOMMENDATIONS = {"BET", "WATCHLIST", "NO BET"}
+
+
+@dataclass(frozen=True)
+class RecommendationThresholds:
+    min_edge_bet: float = 0.050
+    min_edge_watchlist: float = 0.020
+    min_ev_bet: float = 0.030
+    min_ev_watchlist: float = 0.010
+    min_data_quality_bet: int = 85
+    min_data_quality_watchlist: int = 75
+    max_model_market_disagreement: float = 0.120
+
+
+def decimal_odds_to_implied_probability(decimal_odds: float) -> float:
+    if decimal_odds <= 1.0:
+        raise ValueError("Decimal odds must be greater than 1.0.")
+    return 1.0 / decimal_odds
+
+
+def market_implied_probabilities(odds_by_selection: Mapping[str, float]) -> dict[str, float]:
+    if not odds_by_selection:
+        raise ValueError("At least one selection price is required.")
+    return {selection: decimal_odds_to_implied_probability(odds) for selection, odds in odds_by_selection.items()}
+
+
+def bookmaker_margin(raw_probabilities: Mapping[str, float]) -> float:
+    total = sum(raw_probabilities.values())
+    if total <= 0:
+        raise ValueError("Raw implied probabilities must sum above zero.")
+    return total - 1.0
+
+
+def no_vig_probabilities(raw_probabilities: Mapping[str, float]) -> dict[str, float]:
+    total = sum(raw_probabilities.values())
+    if total <= 0:
+        raise ValueError("Raw implied probabilities must sum above zero.")
+    return {selection: probability / total for selection, probability in raw_probabilities.items()}
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    return 1.0 / (1.0 + 10.0 ** ((rating_b - rating_a) / 400.0))
+
+
+def update_elo_rating(rating: float, expected: float, actual: float, k_factor: float = 20.0) -> float:
+    if not 0 <= expected <= 1 or not 0 <= actual <= 1:
+        raise ValueError("Expected and actual scores must be in [0, 1].")
+    return rating + k_factor * (actual - expected)
+
+
+def elo_three_way_proxy(home_elo: float, away_elo: float, draw_rate: float = 0.26) -> dict[str, float]:
+    if not 0 <= draw_rate < 1:
+        raise ValueError("Draw rate must be in [0, 1).")
+    home_binary = expected_score(home_elo, away_elo)
+    non_draw = 1.0 - draw_rate
+    return {
+        "home": home_binary * non_draw,
+        "draw": draw_rate,
+        "away": (1.0 - home_binary) * non_draw,
+    }
+
+
+def glicko_placeholder_rating(rating: float = 1500.0, rating_deviation: float = 350.0, volatility: float = 0.06) -> dict[str, float]:
+    """Return a Phase 3 scaffold object for future Glicko-2 integration."""
+    return {"rating": rating, "rating_deviation": rating_deviation, "volatility": volatility}
+
+
+def rolling_average(values: Iterable[float], window: int = 5) -> float:
+    values = list(values)[-window:]
+    if not values:
+        raise ValueError("xG history is mandatory and cannot be empty.")
+    if any(value < 0 for value in values):
+        raise ValueError("xG values cannot be negative.")
+    return sum(values) / len(values)
+
+
+def derive_expected_goals(home_xg_for: Iterable[float], home_xg_against: Iterable[float], away_xg_for: Iterable[float], away_xg_against: Iterable[float]) -> tuple[float, float]:
+    """Derive simple expected-goals inputs from rolling xG for/against histories."""
+    home_attack = rolling_average(home_xg_for)
+    away_defence_allowed = rolling_average(away_xg_against)
+    away_attack = rolling_average(away_xg_for)
+    home_defence_allowed = rolling_average(home_xg_against)
+    return ((home_attack + away_defence_allowed) / 2.0, (away_attack + home_defence_allowed) / 2.0)
+
+
+def _poisson_pmf(lam: float, goals: int) -> float:
+    if lam < 0:
+        raise ValueError("Expected goals cannot be negative.")
+    return (exp(-lam) * lam**goals) / factorial(goals)
+
+
+def poisson_scoreline_matrix(home_expected_goals: float, away_expected_goals: float, max_goals: int = 10) -> dict[tuple[int, int], float]:
+    if home_expected_goals < 0 or away_expected_goals < 0:
+        raise ValueError("Expected goals cannot be negative.")
+    matrix: dict[tuple[int, int], float] = {}
+    for home_goals in range(max_goals + 1):
+        for away_goals in range(max_goals + 1):
+            matrix[(home_goals, away_goals)] = _poisson_pmf(home_expected_goals, home_goals) * _poisson_pmf(away_expected_goals, away_goals)
+    total = sum(matrix.values())
+    if total <= 0:
+        raise ValueError("Poisson scoreline matrix failed to normalize.")
+    return {score: probability / total for score, probability in matrix.items()}
+
+
+def poisson_market_probabilities(market: str, home_expected_goals: float, away_expected_goals: float) -> dict[str, float]:
+    if market not in SUPPORTED_MARKETS:
+        raise ValueError(f"Unsupported market: {market}")
+    matrix = poisson_scoreline_matrix(home_expected_goals, away_expected_goals)
+
+    if market == "1X2":
+        raw = {
+            "home": sum(prob for (home, away), prob in matrix.items() if home > away),
+            "draw": sum(prob for (home, away), prob in matrix.items() if home == away),
+            "away": sum(prob for (home, away), prob in matrix.items() if home < away),
+        }
+    elif market == "OVER_UNDER_2_5":
+        raw = {
+            "over_2_5": sum(prob for (home, away), prob in matrix.items() if home + away > 2.5),
+            "under_2_5": sum(prob for (home, away), prob in matrix.items() if home + away < 2.5),
+        }
+    else:
+        raw = {
+            "yes": sum(prob for (home, away), prob in matrix.items() if home > 0 and away > 0),
+            "no": sum(prob for (home, away), prob in matrix.items() if home == 0 or away == 0),
+        }
+
+    return no_vig_probabilities(raw)
+
+
+def weighted_probability_blend(probability_sets: list[Mapping[str, float]], weights: list[float]) -> dict[str, float]:
+    if len(probability_sets) != len(weights) or not probability_sets:
+        raise ValueError("Probability sets and weights must be non-empty and aligned.")
+    if any(weight < 0 for weight in weights) or sum(weights) <= 0:
+        raise ValueError("Weights must be non-negative and sum above zero.")
+    normalized_weights = [weight / sum(weights) for weight in weights]
+    selections = set(probability_sets[0].keys())
+    if any(set(probability_set.keys()) != selections for probability_set in probability_sets):
+        raise ValueError("All probability sets must contain identical selections.")
+    blended = {
+        selection: sum(probability_set[selection] * weight for probability_set, weight in zip(probability_sets, normalized_weights))
+        for selection in selections
+    }
+    return no_vig_probabilities(blended)
+
+
+def calculate_expected_value(model_probability: float, decimal_odds: float) -> float:
+    if not 0 <= model_probability <= 1:
+        raise ValueError("Model probability must be in [0, 1].")
+    if decimal_odds <= 1:
+        raise ValueError("Decimal odds must be greater than 1.0.")
+    return (model_probability * decimal_odds) - 1.0
+
+
+def calculate_edge(model_probability: float, bookie_probability: float) -> float:
+    if not 0 <= model_probability <= 1 or not 0 <= bookie_probability <= 1:
+        raise ValueError("Probabilities must be in [0, 1].")
+    return model_probability - bookie_probability
+
+
+def fair_odds(model_probability: float) -> float:
+    if model_probability <= 0:
+        return float("inf")
+    if model_probability > 1:
+        raise ValueError("Model probability cannot exceed 1.")
+    return 1.0 / model_probability
+
+
+def minimum_acceptable_odds(model_probability: float, required_ev: float = 0.0) -> float:
+    if model_probability <= 0:
+        return float("inf")
+    if required_ev < -1:
+        raise ValueError("Required expected value cannot be lower than -1.")
+    return (1.0 + required_ev) / model_probability
+
+
+def brier_score(predicted_probability: float, actual_outcome: int) -> float:
+    if not 0 <= predicted_probability <= 1 or actual_outcome not in {0, 1}:
+        raise ValueError("Brier score expects probability in [0, 1] and binary actual outcome.")
+    return (predicted_probability - actual_outcome) ** 2
+
+
+def log_loss(predicted_probability: float, actual_outcome: int, epsilon: float = 1e-15) -> float:
+    if actual_outcome not in {0, 1}:
+        raise ValueError("Log loss expects binary actual outcome.")
+    p = min(max(predicted_probability, epsilon), 1.0 - epsilon)
+    return -(actual_outcome * log(p) + (1 - actual_outcome) * log(1 - p))
+
+
+def calibration_summary(rows: Iterable[Mapping[str, float]]) -> dict[str, float | int]:
+    rows = list(rows)
+    if not rows:
+        return {"count": 0, "mean_brier_score": 0.0, "mean_log_loss": 0.0}
+    return {
+        "count": len(rows),
+        "mean_brier_score": sum(brier_score(float(row["predicted_probability"]), int(row["actual_outcome"])) for row in rows) / len(rows),
+        "mean_log_loss": sum(log_loss(float(row["predicted_probability"]), int(row["actual_outcome"])) for row in rows) / len(rows),
+    }
+
+
+def _validate_market_input(market: str, odds_by_selection: Mapping[str, float]) -> None:
+    if market not in SUPPORTED_MARKETS:
+        raise ValueError(f"Unsupported market: {market}")
+    expected = set(SUPPORTED_MARKETS[market])
+    actual = set(odds_by_selection)
+    if actual != expected:
+        raise ValueError(f"Market {market} requires selections {sorted(expected)}; got {sorted(actual)}.")
+
+
+def generate_market_probabilities(
+    *,
+    market: str,
+    odds_by_selection: Mapping[str, float],
+    home_expected_goals: float,
+    away_expected_goals: float,
+    home_elo_rating: float = 1500.0,
+    away_elo_rating: float = 1500.0,
+    xg_available: bool = True,
+    historical_odds_available: bool = True,
+) -> list[dict[str, float | str]]:
+    if not xg_available:
+        raise ValueError("Mandatory xG data unavailable; probability generation must force NO BET.")
+    if not historical_odds_available:
+        raise ValueError("Mandatory historical odds unavailable; probability generation must force NO BET.")
+    _validate_market_input(market, odds_by_selection)
+
+    raw_market = market_implied_probabilities(odds_by_selection)
+    no_vig = no_vig_probabilities(raw_market)
+    margin = bookmaker_margin(raw_market)
+    poisson = poisson_market_probabilities(market, home_expected_goals, away_expected_goals)
+
+    if market == "1X2":
+        elo = elo_three_way_proxy(home_elo_rating, away_elo_rating)
+        model = weighted_probability_blend([poisson, no_vig, elo], [0.45, 0.35, 0.20])
+    else:
+        model = weighted_probability_blend([poisson, no_vig], [0.60, 0.40])
+
+    return [
+        {
+            "model_version": MODEL_VERSION,
+            "market": market,
+            "selection": selection,
+            "decimal_odds": float(odds_by_selection[selection]),
+            "model_probability": model[selection],
+            "bookie_probability": no_vig[selection],
+            "market_probability_raw": raw_market[selection],
+            "market_probability_no_vig": no_vig[selection],
+            "bookmaker_margin": margin,
+            "edge": calculate_edge(model[selection], no_vig[selection]),
+            "expected_value": calculate_expected_value(model[selection], float(odds_by_selection[selection])),
+            "fair_odds": fair_odds(model[selection]),
+        }
+        for selection in SUPPORTED_MARKETS[market]
+    ]
+
+
+def recommendation_decision(
+    *,
+    edge: float,
+    expected_value: float,
+    data_quality_score: int,
+    xg_available: bool,
+    historical_odds_available: bool,
+    odds_fresh: bool,
+    model_market_disagreement: float,
+    auto_betting_enabled: bool = False,
+    thresholds: RecommendationThresholds | None = None,
+) -> dict[str, str | list[str]]:
+    thresholds = thresholds or RecommendationThresholds()
+    if auto_betting_enabled:
+        raise ValueError("Auto-betting must remain inactive and hard-locked.")
+
+    hard_fail_reasons: list[str] = []
+    if not xg_available:
+        hard_fail_reasons.append("Mandatory xG data unavailable.")
+    if not historical_odds_available:
+        hard_fail_reasons.append("Mandatory historical odds unavailable.")
+    if not odds_fresh:
+        hard_fail_reasons.append("Odds are stale.")
+    if data_quality_score < thresholds.min_data_quality_watchlist:
+        hard_fail_reasons.append("Data quality score below minimum threshold.")
+    if model_market_disagreement > thresholds.max_model_market_disagreement:
+        hard_fail_reasons.append("Model-market disagreement exceeds maximum threshold.")
+
+    if hard_fail_reasons:
+        return {
+            "recommendation": "NO BET",
+            "confidence": "LOW",
+            "risk": "HIGH",
+            "reason": " ".join(hard_fail_reasons),
+            "hard_fail_reasons": hard_fail_reasons,
+        }
+
+    if edge >= thresholds.min_edge_bet and expected_value >= thresholds.min_ev_bet and data_quality_score >= thresholds.min_data_quality_bet:
+        recommendation = "BET"
+        confidence = "HIGH"
+        risk = "LOW"
+        reason = "Positive expected value, sufficient edge, and strong data quality."
+    elif edge >= thresholds.min_edge_watchlist and expected_value >= thresholds.min_ev_watchlist:
+        recommendation = "WATCHLIST"
+        confidence = "LOW"
+        risk = "MEDIUM"
+        reason = "Potential value detected, but final BET threshold is not met."
+    else:
+        recommendation = "NO BET"
+        confidence = "LOW"
+        risk = "MEDIUM"
+        reason = "No sufficient betting edge identified."
+
+    if recommendation not in ALLOWED_RECOMMENDATIONS:
+        raise ValueError(f"Invalid recommendation output: {recommendation}")
+    return {"recommendation": recommendation, "confidence": confidence, "risk": risk, "reason": reason, "hard_fail_reasons": []}
+
+
+def probability_comparison_chart(market: str, selection: str, model_probability: float, bookie_probability: float) -> dict:
+    return {
+        "type": "model_vs_bookie_probability_comparison",
+        "market": market,
+        "selection": selection,
+        "unit": "probability",
+        "series": [
+            {"label": "Model probability", "value": round(model_probability, 6)},
+            {"label": "Bookmaker no-vig probability", "value": round(bookie_probability, 6)},
+        ],
+        "delta": round(model_probability - bookie_probability, 6),
+    }
+
+
+def build_recommendation_payload(
+    *,
+    fixture_id: int,
+    market: str,
+    selection: str,
+    decimal_odds: float,
+    model_probability: float,
+    bookie_probability: float,
+    data_quality_score: int,
+    xg_available: bool,
+    historical_odds_available: bool,
+    odds_fresh: bool = True,
+    auto_betting_enabled: bool = False,
+    audit_source: str = "phase3_direct_request",
+) -> dict:
+    edge = calculate_edge(model_probability, bookie_probability)
+    ev = calculate_expected_value(model_probability, decimal_odds)
+    decision = recommendation_decision(
+        edge=edge,
+        expected_value=ev,
+        data_quality_score=data_quality_score,
+        xg_available=xg_available,
+        historical_odds_available=historical_odds_available,
+        odds_fresh=odds_fresh,
+        model_market_disagreement=abs(edge),
+        auto_betting_enabled=auto_betting_enabled,
+    )
+    chart = probability_comparison_chart(market, selection, model_probability, bookie_probability)
+    return {
+        "fixture_id": fixture_id,
+        "model_version": MODEL_VERSION,
+        "market": market,
+        "selection": selection,
+        "decimal_odds": decimal_odds,
+        "model_probability": model_probability,
+        "bookie_probability": bookie_probability,
+        "edge": edge,
+        "expected_value": ev,
+        "fair_odds": fair_odds(model_probability),
+        "minimum_acceptable_odds": minimum_acceptable_odds(model_probability, required_ev=0.0),
+        "recommendation": decision["recommendation"],
+        "confidence": decision["confidence"],
+        "risk": decision["risk"],
+        "reason": decision["reason"],
+        "hard_fail_reasons": decision["hard_fail_reasons"],
+        "comparison_chart": chart,
+        "audit_trail": {
+            "audit_source": audit_source,
+            "model_version": MODEL_VERSION,
+            "mandatory_xg_available": xg_available,
+            "mandatory_historical_odds_available": historical_odds_available,
+            "odds_fresh": odds_fresh,
+            "data_quality_score": data_quality_score,
+            "auto_betting_enabled": False,
+            "auto_betting_hard_locked": True,
+        },
+    }

--- a/backend/tests/test_phase3_api.py
+++ b/backend/tests/test_phase3_api.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_phase3_model_status_endpoint():
+    response = client.get("/model/status")
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["phase"] == 3
+    assert payload["default_recommendation"] == "NO BET"
+    assert payload["auto_betting_hard_locked"] is True
+
+
+def test_phase3_probability_endpoint():
+    response = client.post(
+        "/probabilities/calculate",
+        json={
+            "market": "1X2",
+            "odds_by_selection": {"home": 2.0, "draw": 3.4, "away": 4.0},
+            "home_expected_goals": 1.55,
+            "away_expected_goals": 1.10,
+            "home_elo_rating": 1520,
+            "away_elo_rating": 1480,
+            "xg_available": True,
+            "historical_odds_available": True,
+        },
+    )
+    assert response.status_code == 200
+    rows = response.json()["data"]
+    assert len(rows) == 3
+    assert round(sum(row["model_probability"] for row in rows), 6) == 1.0
+
+
+def test_phase3_probability_endpoint_blocks_missing_xg():
+    response = client.post(
+        "/probabilities/calculate",
+        json={
+            "market": "BTTS",
+            "odds_by_selection": {"yes": 1.9, "no": 1.95},
+            "home_expected_goals": 1.55,
+            "away_expected_goals": 1.10,
+            "xg_available": False,
+            "historical_odds_available": True,
+        },
+    )
+    assert response.status_code == 422
+    assert "xG" in response.json()["detail"]
+
+
+def test_phase3_recommendation_endpoint_contains_governance_fields():
+    response = client.post(
+        "/recommendations/fixture/direct",
+        json={
+            "fixture_id": 1,
+            "market": "1X2",
+            "selection": "home",
+            "decimal_odds": 2.1,
+            "model_probability": 0.54,
+            "bookie_probability": 0.49,
+            "data_quality_score": 90,
+            "xg_available": True,
+            "historical_odds_available": True,
+            "odds_fresh": True,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["recommendation"] in {"BET", "WATCHLIST", "NO BET"}
+    assert payload["comparison_chart"]["delta"] == round(payload["edge"], 6)
+    assert payload["audit_trail"]["auto_betting_hard_locked"] is True

--- a/backend/tests/test_phase3_probability_engine.py
+++ b/backend/tests/test_phase3_probability_engine.py
@@ -1,0 +1,155 @@
+from backend.app.models.phase3_probability_engine import (
+    ALLOWED_RECOMMENDATIONS,
+    brier_score,
+    bookmaker_margin,
+    build_recommendation_payload,
+    calculate_expected_value,
+    decimal_odds_to_implied_probability,
+    elo_three_way_proxy,
+    generate_market_probabilities,
+    no_vig_probabilities,
+    poisson_market_probabilities,
+    recommendation_decision,
+)
+
+
+def test_market_implied_and_no_vig_probabilities_sum_to_one():
+    raw = {
+        "home": decimal_odds_to_implied_probability(2.0),
+        "draw": decimal_odds_to_implied_probability(3.4),
+        "away": decimal_odds_to_implied_probability(4.0),
+    }
+    assert bookmaker_margin(raw) > 0
+    no_vig = no_vig_probabilities(raw)
+    assert round(sum(no_vig.values()), 6) == 1.0
+
+
+def test_poisson_probabilities_are_normalized_for_supported_markets():
+    for market in ["1X2", "OVER_UNDER_2_5", "BTTS"]:
+        probs = poisson_market_probabilities(market, 1.55, 1.10)
+        assert round(sum(probs.values()), 6) == 1.0
+
+
+def test_elo_proxy_is_normalized():
+    probs = elo_three_way_proxy(1520, 1480)
+    assert round(sum(probs.values()), 6) == 1.0
+
+
+def test_probability_generation_requires_xg_and_historical_odds():
+    try:
+        generate_market_probabilities(
+            market="1X2",
+            odds_by_selection={"home": 2.0, "draw": 3.4, "away": 4.0},
+            home_expected_goals=1.55,
+            away_expected_goals=1.10,
+            xg_available=False,
+            historical_odds_available=True,
+        )
+    except ValueError as exc:
+        assert "xG" in str(exc)
+    else:
+        raise AssertionError("Missing xG must block probability generation.")
+
+    try:
+        generate_market_probabilities(
+            market="BTTS",
+            odds_by_selection={"yes": 1.90, "no": 1.95},
+            home_expected_goals=1.55,
+            away_expected_goals=1.10,
+            xg_available=True,
+            historical_odds_available=False,
+        )
+    except ValueError as exc:
+        assert "historical odds" in str(exc)
+    else:
+        raise AssertionError("Missing historical odds must block probability generation.")
+
+
+def test_probability_generation_outputs_all_required_fields():
+    rows = generate_market_probabilities(
+        market="1X2",
+        odds_by_selection={"home": 2.0, "draw": 3.4, "away": 4.0},
+        home_expected_goals=1.55,
+        away_expected_goals=1.10,
+        home_elo_rating=1520,
+        away_elo_rating=1480,
+    )
+    assert [row["selection"] for row in rows] == ["home", "draw", "away"]
+    assert round(sum(row["model_probability"] for row in rows), 6) == 1.0
+    assert round(sum(row["bookie_probability"] for row in rows), 6) == 1.0
+    for row in rows:
+        for key in [
+            "model_probability",
+            "bookie_probability",
+            "edge",
+            "expected_value",
+            "fair_odds",
+            "bookmaker_margin",
+        ]:
+            assert key in row
+
+
+def test_recommendation_outputs_are_governed():
+    decision = recommendation_decision(
+        edge=0.08,
+        expected_value=0.05,
+        data_quality_score=95,
+        xg_available=True,
+        historical_odds_available=True,
+        odds_fresh=True,
+        model_market_disagreement=0.08,
+    )
+    assert decision["recommendation"] in ALLOWED_RECOMMENDATIONS
+
+    no_bet = recommendation_decision(
+        edge=0.08,
+        expected_value=0.05,
+        data_quality_score=95,
+        xg_available=False,
+        historical_odds_available=True,
+        odds_fresh=True,
+        model_market_disagreement=0.08,
+    )
+    assert no_bet["recommendation"] == "NO BET"
+
+
+def test_recommendation_payload_contains_chart_risk_and_audit_trail():
+    payload = build_recommendation_payload(
+        fixture_id=1,
+        market="1X2",
+        selection="home",
+        decimal_odds=2.10,
+        model_probability=0.54,
+        bookie_probability=0.49,
+        data_quality_score=90,
+        xg_available=True,
+        historical_odds_available=True,
+    )
+    assert payload["recommendation"] in {"BET", "WATCHLIST", "NO BET"}
+    assert payload["comparison_chart"]["type"] == "model_vs_bookie_probability_comparison"
+    assert payload["risk"] in {"LOW", "MEDIUM", "HIGH"}
+    assert payload["audit_trail"]["auto_betting_hard_locked"] is True
+    assert payload["audit_trail"]["auto_betting_enabled"] is False
+
+
+def test_auto_betting_cannot_be_enabled():
+    try:
+        recommendation_decision(
+            edge=0.08,
+            expected_value=0.05,
+            data_quality_score=95,
+            xg_available=True,
+            historical_odds_available=True,
+            odds_fresh=True,
+            model_market_disagreement=0.08,
+            auto_betting_enabled=True,
+        )
+    except ValueError as exc:
+        assert "Auto-betting" in str(exc)
+    else:
+        raise AssertionError("Auto-betting must remain hard-locked.")
+
+
+def test_metrics_helpers():
+    assert calculate_expected_value(0.55, 2.0) > 0
+    assert brier_score(0.7, 1) < brier_score(0.2, 1)

--- a/docs/phase3_model_probability_engine.md
+++ b/docs/phase3_model_probability_engine.md
@@ -1,0 +1,81 @@
+# Phase 3 — Baseline Model and Probability Engine — 20:16, 27.04.2026 Europe/Oslo
+
+## Executive status
+
+Phase 3 adds the first functional baseline probability engine to the Football Edge Intelligence Agent. The implementation remains analytical decision-support only and is not approved for real-money betting.
+
+Default output remains **NO BET** unless data quality, positive expected value, edge, risk controls, and governance checks are satisfied.
+
+## Scope implemented
+
+- Market-implied probability conversion from decimal odds.
+- No-vig bookmaker probability normalization and bookmaker margin calculation.
+- Elo foundation and Glicko scaffold.
+- xG feature support through rolling xG expected-goals derivation.
+- Poisson scoreline matrix with derived market probabilities.
+- Ensemble blending of Poisson/xG, no-vig market baseline, and Elo signals.
+- Brier score and log loss helpers for calibration.
+- Expected value, edge, fair odds, and minimum acceptable odds.
+- Recommendation output restricted to `BET`, `WATCHLIST`, and `NO BET`.
+- Model-vs-bookie probability comparison chart payload.
+- API endpoints for model status, probability calculation, direct recommendations, and backtest summary.
+- Database migration `003_model_probability_engine.sql`.
+
+## Governance controls
+
+Mandatory no-bet conditions:
+
+- Missing historical odds.
+- Missing xG.
+- Stale odds.
+- Data-quality score below threshold.
+- Excessive model-market disagreement.
+- Any attempt to enable auto-betting.
+
+Auto-betting remains inactive and hard-locked.
+
+## API endpoints
+
+```text
+GET  /model/status
+POST /probabilities/calculate
+POST /recommendations/fixture/direct
+POST /backtests/summary
+```
+
+## Recommendation output contract
+
+Every recommendation payload includes:
+
+- `model_probability`
+- `bookie_probability`
+- `edge`
+- `expected_value`
+- `fair_odds`
+- `minimum_acceptable_odds`
+- `recommendation`
+- `confidence`
+- `risk`
+- `reason`
+- `hard_fail_reasons`
+- `comparison_chart`
+- `audit_trail`
+
+## Test and validation commands
+
+```bash
+python scripts/validate_phase3.py
+python -m pytest -vv
+```
+
+## Completion gate
+
+Phase 3 is complete when:
+
+- Market-implied and no-vig probabilities normalize correctly.
+- Poisson-derived probabilities normalize correctly.
+- Missing xG or historical odds blocks probability generation and forces NO BET posture.
+- Recommendation outputs are restricted to BET, WATCHLIST, and NO BET.
+- Comparison chart data is generated for every recommendation.
+- Auto-betting remains inactive and hard-locked.
+- GitHub Actions passes.

--- a/gpt/openapi/phase3_openapi_patch.yaml
+++ b/gpt/openapi/phase3_openapi_patch.yaml
@@ -1,0 +1,124 @@
+openapi: 3.1.0
+info:
+  title: Football Edge Agent Phase 3 API Patch
+  version: 0.3.0-phase3
+  description: Baseline model and probability-engine endpoints for future GPT Actions integration.
+paths:
+  /model/status:
+    get:
+      operationId: getModelStatus
+      summary: Get Phase 3 model status and governance posture.
+      responses:
+        "200":
+          description: Model status response.
+  /probabilities/calculate:
+    post:
+      operationId: calculateProbabilities
+      summary: Calculate baseline model probabilities.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - market
+                - odds_by_selection
+                - home_expected_goals
+                - away_expected_goals
+              properties:
+                market:
+                  type: string
+                  enum: [1X2, OVER_UNDER_2_5, BTTS]
+                odds_by_selection:
+                  type: object
+                  additionalProperties:
+                    type: number
+                home_expected_goals:
+                  type: number
+                  minimum: 0
+                away_expected_goals:
+                  type: number
+                  minimum: 0
+                home_elo_rating:
+                  type: number
+                  default: 1500
+                away_elo_rating:
+                  type: number
+                  default: 1500
+                xg_available:
+                  type: boolean
+                  default: true
+                historical_odds_available:
+                  type: boolean
+                  default: true
+      responses:
+        "200":
+          description: Probability outputs by selection.
+        "422":
+          description: Mandatory data or validation failure.
+  /recommendations/fixture/direct:
+    post:
+      operationId: createDirectRecommendation
+      summary: Create a governed direct recommendation payload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - fixture_id
+                - market
+                - selection
+                - decimal_odds
+                - model_probability
+                - bookie_probability
+                - data_quality_score
+              properties:
+                fixture_id:
+                  type: integer
+                  minimum: 1
+                market:
+                  type: string
+                selection:
+                  type: string
+                decimal_odds:
+                  type: number
+                  exclusiveMinimum: 1
+                model_probability:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                bookie_probability:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                data_quality_score:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+                xg_available:
+                  type: boolean
+                  default: true
+                historical_odds_available:
+                  type: boolean
+                  default: true
+                odds_fresh:
+                  type: boolean
+                  default: true
+                auto_betting_enabled:
+                  type: boolean
+                  default: false
+      responses:
+        "200":
+          description: Recommendation output.
+        "422":
+          description: Mandatory data, governance, or validation failure.
+  /backtests/summary:
+    post:
+      operationId: summarizeBacktest
+      summary: Summarize calibration rows with Brier score and log loss.
+      responses:
+        "200":
+          description: Backtest summary response.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "football-edge-agent"
-version = "0.2.0"
-description = "Phase 2 FastAPI/PostgreSQL backend foundation for Football Edge Intelligence Agent"
+version = "0.3.0"
+description = "Football Edge Agent backend through Phase 3 baseline probability engine"
 requires-python = ">=3.11"
 
 [tool.pytest.ini_options]

--- a/scripts/validate_phase3.py
+++ b/scripts/validate_phase3.py
@@ -1,0 +1,51 @@
+"""Static Phase 3 validation guardrail.
+
+This script is intentionally simple and CI-friendly. It verifies that the
+Phase 3 package preserves mandatory governance constraints.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = [
+    "backend/app/models/phase3_probability_engine.py",
+    "backend/app/api/phase3.py",
+    "backend/app/db/migrations/003_model_probability_engine.sql",
+    "backend/tests/test_phase3_probability_engine.py",
+    "backend/tests/test_phase3_api.py",
+    "docs/phase3_model_probability_engine.md",
+]
+
+REQUIRED_TERMS = [
+    "NO BET",
+    "historical odds",
+    "xG",
+    "auto_betting_hard_locked",
+    "BET",
+    "WATCHLIST",
+]
+
+
+def main() -> int:
+    missing = [path for path in REQUIRED_FILES if not (ROOT / path).exists()]
+    if missing:
+        raise SystemExit(f"Missing Phase 3 files: {missing}")
+
+    combined = "\n".join((ROOT / path).read_text(encoding="utf-8") for path in REQUIRED_FILES)
+    missing_terms = [term for term in REQUIRED_TERMS if term not in combined]
+    if missing_terms:
+        raise SystemExit(f"Missing mandatory Phase 3 governance terms: {missing_terms}")
+
+    forbidden = ["sure-win", "banker", "guaranteed pick", "loss chasing"]
+    forbidden_found = [term for term in forbidden if term in combined.lower()]
+    if forbidden_found:
+        raise SystemExit(f"Forbidden betting language found: {forbidden_found}")
+
+    print("Phase 3 static validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements Phase 3: Baseline Model and Probability Engine.

### Added

- Market-implied probability conversion from decimal odds.
- No-vig bookmaker probability normalization and bookmaker margin calculation.
- Elo foundation and Glicko scaffold.
- xG-supported expected-goals helpers.
- Poisson scoreline matrix and market probability derivation for 1X2, O/U 2.5, and BTTS.
- Ensemble probability blending.
- Brier score, log loss, and calibration summary helpers.
- Expected value, edge, fair odds, and minimum acceptable odds.
- Governed recommendation engine limited to `BET`, `WATCHLIST`, and `NO BET`.
- Model probability vs bookmaker probability comparison chart output.
- Phase 3 API routes: `/model/status`, `/probabilities/calculate`, `/recommendations/fixture/direct`, `/backtests/summary`.
- Database migration `003_model_probability_engine.sql`.
- Phase 3 tests, validator, CI workflow, methodology documentation, and OpenAPI patch.

### Governance preserved

- Default recommendation remains `NO BET`.
- Historical odds and xG remain mandatory.
- Auto-betting remains inactive and hard-locked.
- No real-money betting approval is introduced.
- Unsupported markets and unsupported competitions remain out of scope.

### Validation

Local package validation before import: 20/20 Phase 3 smoke tests passed.
Local integration validation against a temporary Phase 2 scaffold: 13/13 tests passed.

GitHub Actions must pass before merge.